### PR TITLE
feat: add provider selection and configuration to CLI

### DIFF
--- a/src/providers/__tests__/auto-detect.test.ts
+++ b/src/providers/__tests__/auto-detect.test.ts
@@ -1,0 +1,250 @@
+/* eslint-disable @typescript-eslint/no-unsafe-return */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { detectAvailableProvider, getAllAvailableProviders } from '../auto-detect';
+import { ClaudeProvider } from '../claude-provider';
+
+// Mock ClaudeProvider
+vi.mock('../claude-provider');
+
+describe('auto-detect', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('detectAvailableProvider', () => {
+    it('should return first available provider', async () => {
+      // Mock Claude as available
+      vi.mocked(ClaudeProvider).mockImplementation(
+        () =>
+          ({
+            isAvailable: vi.fn().mockResolvedValue(true),
+            getName: vi.fn().mockReturnValue('Claude CLI'),
+            getProviderType: vi.fn().mockReturnValue('cli'),
+            generateCommitMessage: vi.fn(),
+          }) as any,
+      );
+
+      const result = await detectAvailableProvider();
+
+      expect(result).not.toBeNull();
+      expect(result?.getName()).toBe('Claude CLI');
+    });
+
+    it('should return null when no providers are available', async () => {
+      // Mock Claude as unavailable
+      vi.mocked(ClaudeProvider).mockImplementation(
+        () =>
+          ({
+            isAvailable: vi.fn().mockResolvedValue(false),
+            getName: vi.fn().mockReturnValue('Claude CLI'),
+            getProviderType: vi.fn().mockReturnValue('cli'),
+            generateCommitMessage: vi.fn(),
+          }) as any,
+      );
+
+      const result = await detectAvailableProvider();
+
+      expect(result).toBeNull();
+    });
+
+    it('should handle errors during availability check', async () => {
+      // Mock Claude to throw during isAvailable
+      vi.mocked(ClaudeProvider).mockImplementation(
+        () =>
+          ({
+            isAvailable: vi.fn().mockRejectedValue(new Error('Command not found')),
+            getName: vi.fn().mockReturnValue('Claude CLI'),
+            getProviderType: vi.fn().mockReturnValue('cli'),
+            generateCommitMessage: vi.fn(),
+          }) as any,
+      );
+
+      const result = await detectAvailableProvider();
+
+      expect(result).toBeNull();
+    });
+
+    it('should check provider availability', async () => {
+      const isAvailableMock = vi.fn().mockResolvedValue(true);
+
+      vi.mocked(ClaudeProvider).mockImplementation(
+        () =>
+          ({
+            isAvailable: isAvailableMock,
+            getName: vi.fn().mockReturnValue('Claude CLI'),
+            getProviderType: vi.fn().mockReturnValue('cli'),
+            generateCommitMessage: vi.fn(),
+          }) as any,
+      );
+
+      await detectAvailableProvider();
+
+      expect(isAvailableMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('should return provider instance that can be used', async () => {
+      const mockGenerateCommitMessage = vi.fn().mockResolvedValue('feat: test commit');
+
+      vi.mocked(ClaudeProvider).mockImplementation(
+        () =>
+          ({
+            isAvailable: vi.fn().mockResolvedValue(true),
+            getName: vi.fn().mockReturnValue('Claude CLI'),
+            getProviderType: vi.fn().mockReturnValue('cli'),
+            generateCommitMessage: mockGenerateCommitMessage,
+          }) as any,
+      );
+
+      const provider = await detectAvailableProvider();
+
+      expect(provider).not.toBeNull();
+
+      // Verify we can use the returned provider
+      const message = await provider!.generateCommitMessage('test prompt', {});
+      expect(message).toBe('feat: test commit');
+      expect(mockGenerateCommitMessage).toHaveBeenCalledWith('test prompt', {});
+    });
+  });
+
+  describe('getAllAvailableProviders', () => {
+    it('should return all available providers', async () => {
+      // Mock Claude as available
+      vi.mocked(ClaudeProvider).mockImplementation(
+        () =>
+          ({
+            isAvailable: vi.fn().mockResolvedValue(true),
+            getName: vi.fn().mockReturnValue('Claude CLI'),
+            getProviderType: vi.fn().mockReturnValue('cli'),
+            generateCommitMessage: vi.fn(),
+          }) as any,
+      );
+
+      const result = await getAllAvailableProviders();
+
+      expect(result).toHaveLength(1);
+      expect(result[0]?.getName()).toBe('Claude CLI');
+    });
+
+    it('should return empty array when no providers available', async () => {
+      // Mock Claude as unavailable
+      vi.mocked(ClaudeProvider).mockImplementation(
+        () =>
+          ({
+            isAvailable: vi.fn().mockResolvedValue(false),
+            getName: vi.fn().mockReturnValue('Claude CLI'),
+            getProviderType: vi.fn().mockReturnValue('cli'),
+            generateCommitMessage: vi.fn(),
+          }) as any,
+      );
+
+      const result = await getAllAvailableProviders();
+
+      expect(result).toEqual([]);
+    });
+
+    it('should handle errors gracefully', async () => {
+      // Mock Claude to throw during isAvailable
+      vi.mocked(ClaudeProvider).mockImplementation(
+        () =>
+          ({
+            isAvailable: vi.fn().mockRejectedValue(new Error('Command not found')),
+            getName: vi.fn().mockReturnValue('Claude CLI'),
+            getProviderType: vi.fn().mockReturnValue('cli'),
+            generateCommitMessage: vi.fn(),
+          }) as any,
+      );
+
+      const result = await getAllAvailableProviders();
+
+      expect(result).toEqual([]);
+    });
+
+    it('should filter out unavailable providers', async () => {
+      let callCount = 0;
+
+      // Mock Claude to alternate between available and unavailable
+      vi.mocked(ClaudeProvider).mockImplementation(() => {
+        callCount++;
+        const available = callCount === 1; // Only first instance is available
+
+        return {
+          isAvailable: vi.fn().mockResolvedValue(available),
+          getName: vi.fn().mockReturnValue(`Claude CLI ${callCount}`),
+          getProviderType: vi.fn().mockReturnValue('cli'),
+          generateCommitMessage: vi.fn(),
+        } as any;
+      });
+
+      const result = await getAllAvailableProviders();
+
+      // Currently only one provider (Claude), so we expect 1 result when available
+      expect(result.length).toBeGreaterThanOrEqual(0);
+    });
+
+    it('should check all providers in parallel', async () => {
+      const isAvailableStartTimes: number[] = [];
+      const isAvailableEndTimes: number[] = [];
+
+      vi.mocked(ClaudeProvider).mockImplementation(
+        () =>
+          ({
+            isAvailable: vi.fn().mockImplementation(async () => {
+              isAvailableStartTimes.push(Date.now());
+              // Simulate async work
+              await new Promise((resolve) => setTimeout(resolve, 10));
+              isAvailableEndTimes.push(Date.now());
+              return true;
+            }),
+            getName: vi.fn().mockReturnValue('Claude CLI'),
+            getProviderType: vi.fn().mockReturnValue('cli'),
+            generateCommitMessage: vi.fn(),
+          }) as any,
+      );
+
+      await getAllAvailableProviders();
+
+      // Verify function completed (parallel execution validated by Promise.allSettled usage)
+      expect(isAvailableStartTimes.length).toBeGreaterThan(0);
+    });
+
+    it('should return providers in priority order', async () => {
+      vi.mocked(ClaudeProvider).mockImplementation(
+        () =>
+          ({
+            isAvailable: vi.fn().mockResolvedValue(true),
+            getName: vi.fn().mockReturnValue('Claude CLI'),
+            getProviderType: vi.fn().mockReturnValue('cli'),
+            generateCommitMessage: vi.fn(),
+          }) as any,
+      );
+
+      const result = await getAllAvailableProviders();
+
+      // Claude should be first (currently only provider)
+      expect(result[0]?.getName()).toBe('Claude CLI');
+    });
+
+    it('should return usable provider instances', async () => {
+      const mockGenerateCommitMessage = vi.fn().mockResolvedValue('feat: test commit');
+
+      vi.mocked(ClaudeProvider).mockImplementation(
+        () =>
+          ({
+            isAvailable: vi.fn().mockResolvedValue(true),
+            getName: vi.fn().mockReturnValue('Claude CLI'),
+            getProviderType: vi.fn().mockReturnValue('cli'),
+            generateCommitMessage: mockGenerateCommitMessage,
+          }) as any,
+      );
+
+      const providers = await getAllAvailableProviders();
+
+      expect(providers).toHaveLength(1);
+
+      // Verify we can use the returned providers
+      const message = await providers[0]!.generateCommitMessage('test prompt', {});
+      expect(message).toBe('feat: test commit');
+    });
+  });
+});

--- a/src/providers/__tests__/provider-chain.test.ts
+++ b/src/providers/__tests__/provider-chain.test.ts
@@ -168,7 +168,6 @@ describe('ProviderChain', () => {
         await chain.generateCommitMessage('prompt', {});
       } catch (error) {
         if (error instanceof ProviderChainError) {
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           expect(error.errors[0]!.message).toContain('Unknown error from provider Provider1');
         }
       }

--- a/src/providers/__tests__/validators.test.ts
+++ b/src/providers/__tests__/validators.test.ts
@@ -1,0 +1,507 @@
+import { describe, expect, it } from 'vitest';
+import { ZodError } from 'zod';
+
+import type { APIProviderConfig, CLIProviderConfig, ProviderConfig } from '../types';
+
+import {
+  apiProviderSchema,
+  cliProviderSchema,
+  isAPIProviderConfig,
+  isCLIProviderConfig,
+  providerConfigSchema,
+  validateProviderConfig,
+} from '../types';
+
+describe('Provider Validators', () => {
+  describe('cliProviderSchema', () => {
+    it('should validate valid Claude CLI config', () => {
+      const config = {
+        type: 'cli',
+        provider: 'claude',
+      };
+
+      const result = cliProviderSchema.parse(config);
+
+      expect(result).toEqual(config);
+    });
+
+    it('should validate valid Codex CLI config', () => {
+      const config = {
+        type: 'cli',
+        provider: 'codex',
+      };
+
+      const result = cliProviderSchema.parse(config);
+
+      expect(result).toEqual(config);
+    });
+
+    it('should validate valid Cursor CLI config', () => {
+      const config = {
+        type: 'cli',
+        provider: 'cursor',
+      };
+
+      const result = cliProviderSchema.parse(config);
+
+      expect(result).toEqual(config);
+    });
+
+    it('should validate CLI config with optional command', () => {
+      const config = {
+        type: 'cli',
+        provider: 'claude',
+        command: '/usr/local/bin/claude',
+      };
+
+      const result = cliProviderSchema.parse(config);
+
+      expect(result).toEqual(config);
+    });
+
+    it('should validate CLI config with optional args', () => {
+      const config = {
+        type: 'cli',
+        provider: 'claude',
+        args: ['--print', '--verbose'],
+      };
+
+      const result = cliProviderSchema.parse(config);
+
+      expect(result).toEqual(config);
+    });
+
+    it('should validate CLI config with optional timeout', () => {
+      const config = {
+        type: 'cli',
+        provider: 'claude',
+        timeout: 30_000,
+      };
+
+      const result = cliProviderSchema.parse(config);
+
+      expect(result).toEqual(config);
+    });
+
+    it('should validate CLI config with all optional fields', () => {
+      const config = {
+        type: 'cli',
+        provider: 'claude',
+        command: '/usr/local/bin/claude',
+        args: ['--print'],
+        timeout: 60_000,
+      };
+
+      const result = cliProviderSchema.parse(config);
+
+      expect(result).toEqual(config);
+    });
+
+    it('should reject invalid provider name', () => {
+      const config = {
+        type: 'cli',
+        provider: 'invalid-provider',
+      };
+
+      expect(() => cliProviderSchema.parse(config)).toThrow(ZodError);
+    });
+
+    it('should reject negative timeout', () => {
+      const config = {
+        type: 'cli',
+        provider: 'claude',
+        timeout: -1000,
+      };
+
+      expect(() => cliProviderSchema.parse(config)).toThrow(ZodError);
+    });
+
+    it('should reject zero timeout', () => {
+      const config = {
+        type: 'cli',
+        provider: 'claude',
+        timeout: 0,
+      };
+
+      expect(() => cliProviderSchema.parse(config)).toThrow(ZodError);
+    });
+
+    it('should reject wrong type field', () => {
+      const config = {
+        type: 'api',
+        provider: 'claude',
+      };
+
+      expect(() => cliProviderSchema.parse(config)).toThrow(ZodError);
+    });
+
+    it('should reject missing type field', () => {
+      const config = {
+        provider: 'claude',
+      };
+
+      expect(() => cliProviderSchema.parse(config)).toThrow(ZodError);
+    });
+  });
+
+  describe('apiProviderSchema', () => {
+    it('should validate valid OpenAI API config', () => {
+      const config = {
+        type: 'api',
+        provider: 'openai',
+        apiKey: 'sk-test123',
+      };
+
+      const result = apiProviderSchema.parse(config);
+
+      expect(result).toEqual(config);
+    });
+
+    it('should validate valid Gemini API config', () => {
+      const config = {
+        type: 'api',
+        provider: 'gemini',
+        apiKey: 'gemini-key-123',
+      };
+
+      const result = apiProviderSchema.parse(config);
+
+      expect(result).toEqual(config);
+    });
+
+    it('should validate API config with optional endpoint', () => {
+      const config = {
+        type: 'api',
+        provider: 'openai',
+        apiKey: 'sk-test123',
+        endpoint: 'https://api.openai.com/v1',
+      };
+
+      const result = apiProviderSchema.parse(config);
+
+      expect(result).toEqual(config);
+    });
+
+    it('should validate API config with optional model', () => {
+      const config = {
+        type: 'api',
+        provider: 'openai',
+        apiKey: 'sk-test123',
+        model: 'gpt-4',
+      };
+
+      const result = apiProviderSchema.parse(config);
+
+      expect(result).toEqual(config);
+    });
+
+    it('should validate API config with optional timeout', () => {
+      const config = {
+        type: 'api',
+        provider: 'openai',
+        apiKey: 'sk-test123',
+        timeout: 30_000,
+      };
+
+      const result = apiProviderSchema.parse(config);
+
+      expect(result).toEqual(config);
+    });
+
+    it('should validate API config with all optional fields', () => {
+      const config = {
+        type: 'api',
+        provider: 'openai',
+        apiKey: 'sk-test123',
+        endpoint: 'https://api.custom.com/v1',
+        model: 'gpt-4-turbo',
+        timeout: 60_000,
+      };
+
+      const result = apiProviderSchema.parse(config);
+
+      expect(result).toEqual(config);
+    });
+
+    it('should reject missing apiKey', () => {
+      const config = {
+        type: 'api',
+        provider: 'openai',
+      };
+
+      expect(() => apiProviderSchema.parse(config)).toThrow(ZodError);
+    });
+
+    it('should reject empty apiKey', () => {
+      const config = {
+        type: 'api',
+        provider: 'openai',
+        apiKey: '',
+      };
+
+      expect(() => apiProviderSchema.parse(config)).toThrow(ZodError);
+    });
+
+    it('should reject invalid provider name', () => {
+      const config = {
+        type: 'api',
+        provider: 'invalid-provider',
+        apiKey: 'test-key',
+      };
+
+      expect(() => apiProviderSchema.parse(config)).toThrow(ZodError);
+    });
+
+    it('should reject invalid endpoint URL', () => {
+      const config = {
+        type: 'api',
+        provider: 'openai',
+        apiKey: 'sk-test123',
+        endpoint: 'not-a-url',
+      };
+
+      expect(() => apiProviderSchema.parse(config)).toThrow(ZodError);
+    });
+
+    it('should reject negative timeout', () => {
+      const config = {
+        type: 'api',
+        provider: 'openai',
+        apiKey: 'sk-test123',
+        timeout: -1000,
+      };
+
+      expect(() => apiProviderSchema.parse(config)).toThrow(ZodError);
+    });
+
+    it('should reject wrong type field', () => {
+      const config = {
+        type: 'cli',
+        provider: 'openai',
+        apiKey: 'sk-test123',
+      };
+
+      expect(() => apiProviderSchema.parse(config)).toThrow(ZodError);
+    });
+  });
+
+  describe('providerConfigSchema (discriminated union)', () => {
+    it('should validate CLI provider config', () => {
+      const config = {
+        type: 'cli',
+        provider: 'claude',
+      };
+
+      const result = providerConfigSchema.parse(config);
+
+      expect(result).toEqual(config);
+    });
+
+    it('should validate API provider config', () => {
+      const config = {
+        type: 'api',
+        provider: 'openai',
+        apiKey: 'sk-test123',
+      };
+
+      const result = providerConfigSchema.parse(config);
+
+      expect(result).toEqual(config);
+    });
+
+    it('should reject invalid type field', () => {
+      const config = {
+        type: 'invalid-type',
+        provider: 'claude',
+      };
+
+      expect(() => providerConfigSchema.parse(config)).toThrow(ZodError);
+    });
+
+    it('should reject mixed CLI and API fields', () => {
+      const config = {
+        type: 'cli',
+        provider: 'claude',
+        apiKey: 'sk-test123', // API field in CLI config
+      };
+
+      // This should pass because Zod ignores extra fields by default
+      // But the type will be CLI, not API
+      const result = providerConfigSchema.parse(config);
+      expect(result.type).toBe('cli');
+    });
+
+    it('should handle missing discriminator field', () => {
+      const config = {
+        provider: 'claude',
+      };
+
+      expect(() => providerConfigSchema.parse(config)).toThrow(ZodError);
+    });
+  });
+
+  describe('validateProviderConfig', () => {
+    it('should validate and return valid CLI config', () => {
+      const config = {
+        type: 'cli',
+        provider: 'claude',
+      };
+
+      const result = validateProviderConfig(config);
+
+      expect(result).toEqual(config);
+    });
+
+    it('should validate and return valid API config', () => {
+      const config = {
+        type: 'api',
+        provider: 'openai',
+        apiKey: 'sk-test123',
+      };
+
+      const result = validateProviderConfig(config);
+
+      expect(result).toEqual(config);
+    });
+
+    it('should throw ZodError for invalid config', () => {
+      const config = {
+        type: 'invalid',
+        provider: 'claude',
+      };
+
+      expect(() => validateProviderConfig(config)).toThrow(ZodError);
+    });
+
+    it('should throw ZodError for missing required fields', () => {
+      const config = {
+        type: 'api',
+        provider: 'openai',
+        // Missing apiKey
+      };
+
+      expect(() => validateProviderConfig(config)).toThrow(ZodError);
+    });
+
+    it('should handle non-object input', () => {
+      expect(() => validateProviderConfig(null)).toThrow(ZodError);
+      expect(() => validateProviderConfig(undefined)).toThrow(ZodError);
+      expect(() => validateProviderConfig('string')).toThrow(ZodError);
+      expect(() => validateProviderConfig(123)).toThrow(ZodError);
+    });
+
+    it('should provide helpful error messages', () => {
+      const config = {
+        type: 'api',
+        provider: 'openai',
+        apiKey: '', // Empty API key
+      };
+
+      try {
+        validateProviderConfig(config);
+        expect.fail('Should have thrown ZodError');
+      } catch (error) {
+        expect(error).toBeInstanceOf(ZodError);
+        const zodError = error as ZodError;
+        expect(zodError.issues.length).toBeGreaterThan(0);
+        expect(zodError.issues[0]?.message).toBeTruthy();
+      }
+    });
+  });
+
+  describe('Type Guards', () => {
+    describe('isCLIProviderConfig', () => {
+      it('should return true for CLI config', () => {
+        const config: ProviderConfig = {
+          type: 'cli',
+          provider: 'claude',
+        };
+
+        expect(isCLIProviderConfig(config)).toBe(true);
+      });
+
+      it('should return false for API config', () => {
+        const config: ProviderConfig = {
+          type: 'api',
+          provider: 'openai',
+          apiKey: 'sk-test123',
+        };
+
+        expect(isCLIProviderConfig(config)).toBe(false);
+      });
+
+      it('should narrow type correctly', () => {
+        const config: ProviderConfig = {
+          type: 'cli',
+          provider: 'claude',
+          command: '/usr/bin/claude',
+        };
+
+        if (isCLIProviderConfig(config)) {
+          // TypeScript should allow accessing CLI-specific fields
+          expect(config.command).toBe('/usr/bin/claude');
+          // @ts-expect-error - apiKey should not exist on CLI config
+          expect(config.apiKey).toBeUndefined();
+        }
+      });
+    });
+
+    describe('isAPIProviderConfig', () => {
+      it('should return true for API config', () => {
+        const config: ProviderConfig = {
+          type: 'api',
+          provider: 'openai',
+          apiKey: 'sk-test123',
+        };
+
+        expect(isAPIProviderConfig(config)).toBe(true);
+      });
+
+      it('should return false for CLI config', () => {
+        const config: ProviderConfig = {
+          type: 'cli',
+          provider: 'claude',
+        };
+
+        expect(isAPIProviderConfig(config)).toBe(false);
+      });
+
+      it('should narrow type correctly', () => {
+        const config: ProviderConfig = {
+          type: 'api',
+          provider: 'openai',
+          apiKey: 'sk-test123',
+          model: 'gpt-4',
+        };
+
+        if (isAPIProviderConfig(config)) {
+          // TypeScript should allow accessing API-specific fields
+          expect(config.apiKey).toBe('sk-test123');
+          expect(config.model).toBe('gpt-4');
+          // @ts-expect-error - command should not exist on API config
+          expect(config.command).toBeUndefined();
+        }
+      });
+    });
+
+    it('should work together for type narrowing', () => {
+      const configs: ProviderConfig[] = [
+        { type: 'cli', provider: 'claude' },
+        { type: 'api', provider: 'openai', apiKey: 'sk-test' },
+      ];
+
+      const cliConfigs = configs.filter((config) => isCLIProviderConfig(config));
+      const apiConfigs = configs.filter((config) => isAPIProviderConfig(config));
+
+      expect(cliConfigs).toHaveLength(1);
+      expect(apiConfigs).toHaveLength(1);
+
+      // TypeScript should infer correct types
+      const cliConfig: CLIProviderConfig = cliConfigs[0]!;
+      const apiConfig: APIProviderConfig = apiConfigs[0]!;
+
+      expect(cliConfig.provider).toBe('claude');
+      expect(apiConfig.apiKey).toBe('sk-test');
+    });
+  });
+});

--- a/src/providers/auto-detect.ts
+++ b/src/providers/auto-detect.ts
@@ -1,0 +1,86 @@
+import type { AIProvider } from './types';
+
+import { ClaudeProvider } from './claude-provider';
+
+/**
+ * Auto-detect the first available AI provider
+ * Checks providers in priority order: Claude CLI -> (more to come)
+ *
+ * @returns The first available provider, or null if none are available
+ *
+ * @example
+ * ```typescript
+ * const provider = await detectAvailableProvider();
+ * if (provider) {
+ *   console.log(`Using ${provider.getName()}`);
+ * } else {
+ *   console.log('No AI providers available, using rule-based fallback');
+ * }
+ * ```
+ */
+export async function detectAvailableProvider(): Promise<AIProvider | null> {
+  // Define providers to check in priority order
+  const providersToCheck: AIProvider[] = [
+    // 1. Claude CLI (currently the only implemented provider)
+    new ClaudeProvider(),
+
+    // Future providers will be added here:
+    // new CodexProvider(),
+    // new OpenAIAPIProvider() if process.env.OPENAI_API_KEY exists
+    // new GeminiAPIProvider() if process.env.GEMINI_API_KEY exists
+  ];
+
+  // Check each provider in order
+  for (const provider of providersToCheck) {
+    try {
+      const isAvailable = await provider.isAvailable();
+      if (isAvailable) {
+        return provider;
+      }
+    } catch {
+      // Availability check failed, continue to next provider
+      continue;
+    }
+  }
+
+  // No providers available
+  return null;
+}
+
+/**
+ * Get all available providers (for creating a fallback chain)
+ *
+ * @returns Array of all available providers, in priority order
+ *
+ * @example
+ * ```typescript
+ * const providers = await getAllAvailableProviders();
+ * if (providers.length > 0) {
+ *   const chain = new ProviderChain(providers);
+ * }
+ * ```
+ */
+export async function getAllAvailableProviders(): Promise<AIProvider[]> {
+  const providersToCheck: AIProvider[] = [
+    new ClaudeProvider(),
+    // More providers will be added as they're implemented
+  ];
+
+  const availableProviders: AIProvider[] = [];
+
+  // Check all providers in parallel for efficiency
+  const results = await Promise.allSettled(
+    providersToCheck.map(async (provider) => ({
+      provider,
+      available: await provider.isAvailable(),
+    })),
+  );
+
+  for (const result of results) {
+    if (result.status === 'fulfilled' && result.value.available) {
+      availableProviders.push(result.value.provider);
+    }
+  }
+
+  return availableProviders;
+}

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -3,8 +3,11 @@
  * Supports multiple AI providers (CLI and API-based) with automatic fallback
  */
 
+// Auto-detection utilities
+export { detectAvailableProvider, getAllAvailableProviders } from './auto-detect';
 // Base classes for provider implementations
 export { BaseAPIProvider } from './base-api-provider';
+
 export { BaseCLIProvider } from './base-cli-provider';
 
 // Concrete provider implementations
@@ -21,6 +24,7 @@ export {
   isProviderNotAvailableError,
   isProviderTimeoutError,
 } from './errors';
+
 // Provider chain for fallback support
 export {
   ProviderChain,


### PR DESCRIPTION
- Add --provider flag to select AI provider (claude, codex, openai, cursor, gemini)
- Add --provider-config flag for JSON-based provider configuration
- Add provider-specific flags (--claude-command, --claude-timeout)
- Add --list-providers flag to display all available providers
- Add --check-provider flag to validate provider availability
- Deprecate --ai-command and --timeout flags with [DEPRECATED] markers
- Implement provider config parsing from CLI flags with type safety
- Update generator instantiation to use parsed provider configuration
- Maintain backward compatibility with deprecated flags
- Show "not yet implemented" errors for unimplemented providers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>