### PR TITLE
ci: update publish workflow permissions for release comments

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ jobs:
     name: Publish to npm
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write # Needed to comment on release
       id-token: write # Required for npm provenance
 
     steps:


### PR DESCRIPTION
- Change contents permission from read to write
- Enable GitHub Actions to comment on releases

🤖 Generated with Claude via commitment