### PR TITLE
fix: preserve staged changes after pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,18 @@
 #!/bin/sh
 # Run linting and build to ensure code quality and dist is up to date
+
+# Get list of staged files before linting
+STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM)
+
+# Run linting (which may modify files)
 bun run lint
 bun run build
+
+# Re-stage any files that were modified by linting
+if [ -n "$STAGED_FILES" ]; then
+  echo "$STAGED_FILES" | while IFS= read -r file; do
+    if [ -f "$file" ]; then
+      git add "$file"
+    fi
+  done
+fi


### PR DESCRIPTION
- Store list of staged files before running linting
- Re-stage files modified by linting tools
- Prevent unstaged changes from being excluded from commit

🤖 Generated with Claude via commitment