### PR TITLE
fix: add skip-git-repo-check flag to Codex agent

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   "scripts": {
     "build": "bun run build.ts",
     "check-types": "bun tsc --noEmit",
-    "clean": "rm -rf dist",
+    "clean": "rm -r dist node_modules",
     "dev": "bun --watch build.ts",
     "eval": "bun run src/eval/run-eval.ts",
     "eval:claude": "bun run src/eval/run-eval.ts --agent claude",

--- a/src/agents/__tests__/codex.unit.test.ts
+++ b/src/agents/__tests__/codex.unit.test.ts
@@ -73,6 +73,7 @@ describe('CodexAgent', () => {
         'codex',
         [
           'exec',
+          '--skip-git-repo-check',
           '--output-last-message',
           expect.stringMatching(/\/tmp\/codex-output-\d+\.txt/),
           prompt,

--- a/src/agents/codex.ts
+++ b/src/agents/codex.ts
@@ -46,10 +46,15 @@ export class CodexAgent extends BaseAgent {
 
     try {
       // Execute Codex CLI in non-interactive mode
-      const result = await exec('codex', ['exec', '--output-last-message', tmpFile, prompt], {
-        cwd: workdir,
-        timeout: 120_000, // 2 minutes
-      });
+      // --skip-git-repo-check allows running in non-git directories (needed for eval system using /tmp)
+      const result = await exec(
+        'codex',
+        ['exec', '--skip-git-repo-check', '--output-last-message', tmpFile, prompt],
+        {
+          cwd: workdir,
+          timeout: 120_000, // 2 minutes
+        }
+      );
 
       // Read output from temp file or fallback to stdout
       return await this._readOutput(tmpFile, result.stdout);


### PR DESCRIPTION
- Add `--skip-git-repo-check` flag to Codex CLI execution
- Enable Codex to run in non-git directories (fixes eval system in /tmp)
- Update clean script to remove node_modules directory
- Update test expectations for new command flag

🤖 Generated with Claude via commitment